### PR TITLE
Use the correct default branch for events.

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -12,10 +12,10 @@ name: Check Transpiled JavaScript
 on:
   pull_request:
     branches:
-      - main
+      - trunk
   push:
     branches:
-      - main
+      - trunk
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: Continuous Integration
 on:
   pull_request:
     branches:
-      - main
+      - trunk
   push:
     branches:
-      - main
+      - trunk
 
 permissions:
   contents: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,10 +3,10 @@ name: CodeQL
 on:
   pull_request:
     branches:
-      - main
+      - trunk
   push:
     branches:
-      - main
+      - trunk
   schedule:
     - cron: '31 7 * * 3'
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -3,10 +3,10 @@ name: Lint Codebase
 on:
   pull_request:
     branches:
-      - main
+      - trunk
   push:
     branches:
-      - main
+      - trunk
 
 permissions:
   contents: read
@@ -40,7 +40,7 @@ jobs:
         id: super-linter
         uses: super-linter/super-linter/slim@v7
         env:
-          DEFAULT_BRANCH: main
+          DEFAULT_BRANCH: trunk
           FILTER_REGEX_EXCLUDE: dist/**/*
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TYPESCRIPT_DEFAULT_STYLE: prettier


### PR DESCRIPTION
This changes the branch filtering for `push` and `pull_request` events to use `trunk` instead of `main`.

`main` appears to have been the primary branch in the past, but that is no longer the case.