### PR TITLE
[codex] Use PR head commit for Playground previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To enable the "Try it in Playground" button, create a `.github/workflows/pr-prev
 ```yaml
 name: PR Preview
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, edited]
 
 jobs:
@@ -35,7 +35,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-> **Security note:** The basic workflow above intentionally does not check out or run PR code. It only reads pull request metadata, builds a Playground URL that points at the PR head repository and commit, and updates the pull request description or comment. Keep build steps in a separate `pull_request` workflow; see [Advanced: Testing Built CI Artifacts](#advanced-testing-built-ci-artifacts).
+> **Fork PRs:** The baseline workflow uses `pull_request`. GitHub makes `GITHUB_TOKEN` read-only for pull requests from forks, so the action may not be able to update fork PR descriptions or comments. See [Forked pull requests](#forked-pull-requests) before switching to `pull_request_target`.
 
 > **Important:** `WordPress/action-wp-playground-pr-preview@v2` is a regular action. Always reference it inside a job step (under `jobs.<job_id>.steps`). GitHub only allows `jobs.<job_id>.uses` for reusable workflows that point to another workflow file such as `owner/repo/.github/workflows/workflow.yml@ref`.
 
@@ -54,7 +54,7 @@ See the [preview-in-playground-button-built-artifact-example](#advanced-testing-
 ```yaml
 name: PR Preview
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, edited]
 
 jobs:
@@ -96,7 +96,7 @@ For advanced configurations, you can provide a custom blueprint:
 ```yaml
 name: PR Playground Preview
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, edited]
 
 jobs:
@@ -150,6 +150,32 @@ jobs:
           blueprint: ${{ needs.create-blueprint.outputs.blueprint }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+### Forked pull requests
+
+Use `pull_request` by default. If you need the action to update PR descriptions or comments on pull requests from forks, GitHub requires a privileged workflow such as `pull_request_target`:
+
+```yaml
+name: PR Preview
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Post Playground Preview Button
+        uses: WordPress/action-wp-playground-pr-preview@v2
+        with:
+          plugin-path: .
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Treat `pull_request_target` as privileged. Use it only for metadata-only preview publishing workflows that do **not** check out PR code, run PR-controlled files, install PR dependencies, load a blueprint from the PR branch, or pass PR-controlled values into shell commands. Keep permissions as narrow as possible (`contents: read` and `pull-requests: write` for this action). If the preview needs Composer, npm, tests, or any other execution of PR code, use the two-workflow artifact pattern in [Advanced: Testing Built CI Artifacts](#advanced-testing-built-ci-artifacts).
 
 ### External Blueprint URL
 
@@ -763,7 +789,7 @@ As mentioned in [Advanced: Testing Built CI Artifacts](#advanced-testing-built-c
 
 ### Workflow fails with "Resource not accessible by integration"
 
-Updating PR descriptions or comments requires the workflow (or custom token) to have `pull-requests: write` plus `contents: read`. For fork PRs, `pull_request` workflows get a read-only `GITHUB_TOKEN` even when you request write permissions. Use the basic `pull_request_target` workflow when the action only posts the preview button and does not check out or execute PR code. If you need a build step, use the two-workflow artifact pattern above.
+Updating PR descriptions or comments requires the workflow (or custom token) to have `pull-requests: write` plus `contents: read`. For fork PRs, `pull_request` workflows get a read-only `GITHUB_TOKEN` even when you request write permissions. Use `pull_request_target` only for the constrained metadata-only workflow described in [Forked pull requests](#forked-pull-requests). If you need a build step or any execution of PR code, use the two-workflow artifact pattern above.
 
 ### Step fails with "You must configure plugin-path/theme-path/blueprint"
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To enable the "Try it in Playground" button, create a `.github/workflows/pr-prev
 ```yaml
 name: PR Preview
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, edited]
 
 jobs:
@@ -35,6 +35,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+> **Security note:** The basic workflow above intentionally does not check out or run PR code. It only reads pull request metadata, builds a Playground URL that points at the PR head repository and commit, and updates the pull request description or comment. Keep build steps in a separate `pull_request` workflow; see [Advanced: Testing Built CI Artifacts](#advanced-testing-built-ci-artifacts).
+
 > **Important:** `WordPress/action-wp-playground-pr-preview@v2` is a regular action. Always reference it inside a job step (under `jobs.<job_id>.steps`). GitHub only allows `jobs.<job_id>.uses` for reusable workflows that point to another workflow file such as `owner/repo/.github/workflows/workflow.yml@ref`.
 
 ## Examples
@@ -52,7 +54,7 @@ See the [preview-in-playground-button-built-artifact-example](#advanced-testing-
 ```yaml
 name: PR Preview
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, edited]
 
 jobs:
@@ -94,7 +96,7 @@ For advanced configurations, you can provide a custom blueprint:
 ```yaml
 name: PR Playground Preview
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, edited]
 
 jobs:
@@ -115,8 +117,11 @@ jobs:
                   step: "installPlugin",
                   pluginData: {
                     resource: "git:directory",
-                    url: `https://github.com/${context.repo.owner}/${context.repo.repo}.git`,
-                    ref: context.payload.pull_request.head.ref,
+                    // Use the PR head repo, not context.repo. PRs from forks
+                    // live on the contributor's fork, not the base repository.
+                    url: `https://github.com/${context.payload.pull_request.head.repo.full_name}.git`,
+                    ref: context.payload.pull_request.head.sha,
+                    refType: "commit",
                     path: "/"
                   }
                 },
@@ -320,6 +325,9 @@ The template supports variable interpolation using `{{VARIABLE_NAME}}` syntax (c
 - `{{PR_TITLE}}` - Pull request title
 - `{{PR_HEAD_REF}}` - Source branch name
 - `{{PR_HEAD_SHA}}` - Latest commit SHA
+- `{{PR_HEAD_REPO_OWNER}}` - Source repository owner username/org
+- `{{PR_HEAD_REPO_NAME}}` - Source repository name
+- `{{PR_HEAD_REPO_FULL_NAME}}` - Source repository full name (owner/repo)
 - `{{PR_BASE_REF}}` - Target branch name
 - `{{REPO_OWNER}}` - Repository owner username/org
 - `{{REPO_NAME}}` - Repository name
@@ -755,7 +763,7 @@ As mentioned in [Advanced: Testing Built CI Artifacts](#advanced-testing-built-c
 
 ### Workflow fails with "Resource not accessible by integration"
 
-Updating PR descriptions or comments requires the workflow (or custom token) to have `pull-requests: write` plus `contents: read`. Add the permissions block from the basic example or provide a PAT with the same scopes. Without those permissions GitHub blocks the API call and you will see this error in the `Post Playground Preview Button` step.
+Updating PR descriptions or comments requires the workflow (or custom token) to have `pull-requests: write` plus `contents: read`. For fork PRs, `pull_request` workflows get a read-only `GITHUB_TOKEN` even when you request write permissions. Use the basic `pull_request_target` workflow when the action only posts the preview button and does not check out or execute PR code. If you need a build step, use the two-workflow artifact pattern above.
 
 ### Step fails with "You must configure plugin-path/theme-path/blueprint"
 

--- a/__tests__/blueprint.test.js
+++ b/__tests__/blueprint.test.js
@@ -1,0 +1,108 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const {
+  buildAutoBlueprint,
+  getPullRequestHeadRepository,
+  inferSlug,
+  normalizePath,
+} = require("../src/blueprint");
+
+test("uses the pull request head repository for fork PR previews", () => {
+  const repo = {
+    name: "base-plugin",
+    full_name: "wordpress/base-plugin",
+    owner: { login: "wordpress" },
+  };
+  const pr = {
+    head: {
+      repo: {
+        name: "base-plugin",
+        full_name: "contributor/base-plugin",
+        owner: { login: "contributor" },
+      },
+    },
+  };
+
+  assert.deepEqual(
+    getPullRequestHeadRepository(pr, repo, "wordpress", "base-plugin"),
+    {
+      owner: "contributor",
+      name: "base-plugin",
+      fullName: "contributor/base-plugin",
+      gitUrl: "https://github.com/contributor/base-plugin.git",
+    },
+  );
+});
+
+test("falls back to the base repository when PR head repo metadata is missing", () => {
+  const repo = {
+    name: "base-plugin",
+    full_name: "wordpress/base-plugin",
+    owner: { login: "wordpress" },
+  };
+
+  assert.deepEqual(
+    getPullRequestHeadRepository(
+      { head: {} },
+      repo,
+      "wordpress",
+      "base-plugin",
+    ),
+    {
+      owner: "wordpress",
+      name: "base-plugin",
+      fullName: "wordpress/base-plugin",
+      gitUrl: "https://github.com/wordpress/base-plugin.git",
+    },
+  );
+});
+
+test("builds plugin preview blueprints from the exact PR head commit", () => {
+  const blueprint = JSON.parse(
+    buildAutoBlueprint({
+      pluginPath: ".",
+      repoGitUrl: "https://github.com/contributor/plugin.git",
+      ref: "1234567890abcdef1234567890abcdef12345678",
+    }),
+  );
+
+  assert.deepEqual(blueprint.steps, [
+    {
+      step: "installPlugin",
+      pluginData: {
+        resource: "git:directory",
+        url: "https://github.com/contributor/plugin.git",
+        ref: "1234567890abcdef1234567890abcdef12345678",
+        refType: "commit",
+        path: "/",
+      },
+      options: {
+        activate: true,
+      },
+    },
+  ]);
+});
+
+test("builds theme and plugin previews with normalized subdirectory paths", () => {
+  const blueprint = JSON.parse(
+    buildAutoBlueprint({
+      pluginPath: "./plugins/my-plugin/",
+      themePath: "/themes/my-theme",
+      repoGitUrl: "https://github.com/wordpress/project.git",
+      ref: "abcdefabcdefabcdefabcdefabcdefabcdefabcd",
+    }),
+  );
+
+  assert.equal(blueprint.steps.length, 2);
+  assert.equal(blueprint.steps[0].pluginData.path, "plugins/my-plugin");
+  assert.equal(blueprint.steps[1].themeData.path, "themes/my-theme");
+  assert.equal(blueprint.steps[0].pluginData.refType, "commit");
+  assert.equal(blueprint.steps[1].themeData.refType, "commit");
+});
+
+test("normalizes paths and infers slugs consistently", () => {
+  assert.equal(normalizePath("."), "");
+  assert.equal(normalizePath("./plugins/example/"), "plugins/example");
+  assert.equal(inferSlug("./plugins/my-plugin/", "fallback"), "my-plugin");
+  assert.equal(inferSlug(".", "fallback"), "fallback");
+});

--- a/dist/index.js
+++ b/dist/index.js
@@ -31793,6 +31793,106 @@ function parseParams (str) {
 module.exports = parseParams
 
 
+/***/ }),
+
+/***/ 4307:
+/***/ ((module) => {
+
+function normalizePath(path) {
+  const raw = (path || "").trim();
+  if (!raw || raw === "." || raw === "./") {
+    return "";
+  }
+  return raw.replace(/^\.\/+/, "").replace(/^\/+|\/+$/g, "");
+}
+
+function sanitizeSlug(value, fallback) {
+  if (!value) return fallback;
+  const cleaned = value
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return cleaned || fallback;
+}
+
+function inferSlug(path, fallback) {
+  const clean = normalizePath(path).split("/").filter(Boolean).pop();
+  if (!clean || clean === "." || clean === "..") return fallback;
+  return sanitizeSlug(clean, fallback);
+}
+
+function getRepoOwner(repo, fallback) {
+  return repo?.owner?.login || repo?.owner?.name || repo?.owner?.id || fallback;
+}
+
+function getPullRequestHeadRepository(
+  pr,
+  fallbackRepo,
+  fallbackOwner,
+  fallbackRepoName,
+) {
+  const headRepo = pr.head?.repo || fallbackRepo || {};
+  const owner = getRepoOwner(headRepo, fallbackOwner);
+  const name = headRepo.name || fallbackRepoName;
+  const fullName = headRepo.full_name || `${owner}/${name}`;
+
+  return {
+    owner,
+    name,
+    fullName,
+    gitUrl: `https://github.com/${fullName}.git`,
+  };
+}
+
+function buildAutoBlueprint({ pluginPath, themePath, repoGitUrl, ref }) {
+  const steps = [];
+  const gitDirectoryResource = (path) => ({
+    resource: "git:directory",
+    url: repoGitUrl,
+    ref,
+    refType: "commit",
+    path: normalizePath(path) || "/",
+  });
+
+  if (pluginPath) {
+    steps.push({
+      step: "installPlugin",
+      pluginData: gitDirectoryResource(pluginPath),
+      options: {
+        activate: true,
+      },
+    });
+  }
+
+  if (themePath) {
+    steps.push({
+      step: "installTheme",
+      themeData: gitDirectoryResource(themePath),
+      options: {
+        activate: true,
+      },
+    });
+  }
+
+  return JSON.stringify({
+    $schema: "https://playground.wordpress.net/blueprint-schema.json",
+    preferredVersions: {
+      php: "8.2",
+      wp: "latest",
+    },
+    steps,
+  });
+}
+
+module.exports = {
+  buildAutoBlueprint,
+  getPullRequestHeadRepository,
+  inferSlug,
+  normalizePath,
+  sanitizeSlug,
+};
+
+
 /***/ })
 
 /******/ 	});
@@ -31836,6 +31936,12 @@ module.exports = parseParams
 var __webpack_exports__ = {};
 const core = __nccwpck_require__(7484);
 const githubLib = __nccwpck_require__(3228);
+const {
+  buildAutoBlueprint,
+  getPullRequestHeadRepository,
+  inferSlug,
+  sanitizeSlug,
+} = __nccwpck_require__(4307);
 
 (async () => {
   const context = githubLib.context;
@@ -31894,6 +32000,10 @@ const githubLib = __nccwpck_require__(3228);
   const prTitle = pr.title;
   const headRef = pr.head.ref;
   const headSha = pr.head.sha;
+  const headRepo = getPullRequestHeadRepository(pr, repo, owner, repoName);
+  const headRepoOwner = headRepo.owner;
+  const headRepoName = headRepo.name;
+  const headRepoFullName = headRepo.fullName;
   const baseRef = pr.base.ref;
 
   const playgroundHostRaw = core.getInput('playground-host', {required: false}) || 'https://playground.wordpress.net';
@@ -31928,87 +32038,21 @@ const githubLib = __nccwpck_require__(3228);
 
   const archiveBranchSegment = headRef.replace(/[^0-9A-Za-z]/g, '-');
   const repoArchiveRoot = `${repoName}-${archiveBranchSegment}`;
-  const repoGitUrl = `https://github.com/${repoFullName}.git`;
-
-  const normalizePath = (path) => {
-    const raw = (path || '').trim();
-    if (!raw || raw === '.' || raw === './') {
-  	return '';
-    }
-    return raw.replace(/^\.\/+/, '').replace(/^\/+|\/+$/g, '');
-  };
-  const sanitizeSlug = (value, fallback) => {
-    if (!value) return fallback;
-    const cleaned = value
-  	.toLowerCase()
-  	.replace(/[^a-z0-9-]+/g, '-')
-  	.replace(/^-+|-+$/g, '');
-    return cleaned || fallback;
-  };
   const repoSlug = sanitizeSlug(repoName, 'project');
-  const inferSlug = (path, fallback) => {
-    const clean = normalizePath(path).split('/').filter(Boolean).pop();
-    if (!clean || clean === '.' || clean === '..') return fallback;
-    return sanitizeSlug(clean, fallback);
-  };
 
   const pluginSlug = pluginPath ? inferSlug(pluginPath, repoSlug) : '';
   const themeSlug = themePath ? inferSlug(themePath, `${repoSlug}-theme`) : '';
-
-  const buildAutoBlueprint = () => {
-    const steps = [];
-
-    if (pluginPath) {
-  	steps.push(
-  	  {
-  		step: 'installPlugin',
-  		pluginData: {
-  		  resource: 'git:directory',
-  		  url: repoGitUrl,
-  		  ref: headRef,
-  		  path: normalizePath(pluginPath) || "/"
-  		},
-  		options: {
-  		  activate: true
-  		}
-  	  }
-  	);
-    }
-
-    if (themePath) {
-  	steps.push(
-  	  {
-  		step: 'installTheme',
-  		themeData: {
-  		  resource: 'git:directory',
-  		  url: repoGitUrl,
-  		  ref: headRef,
-  		  path: normalizePath(themePath) || "/"
-  		},
-  		options: {
-  		  activate: true
-  		}
-  	  }
-  	);
-    }
-
-    return JSON.stringify(
-  	{
-  	  $schema: 'https://playground.wordpress.net/blueprint-schema.json',
-  	  preferredVersions: {
-  		php: '8.2',
-  		wp: 'latest'
-  	  },
-  	  steps
-  	}
-    );
-  };
 
   let blueprintJson = '';
   if (blueprintInput && blueprintInput.trim().length) {
     blueprintJson = blueprintInput.trim();
   } else if (pluginPath || themePath) {
-    blueprintJson = buildAutoBlueprint();
+    blueprintJson = buildAutoBlueprint({
+      pluginPath,
+      themePath,
+      repoGitUrl: headRepo.gitUrl,
+      ref: headSha,
+    });
   }
 
   if (blueprintJson) {
@@ -32089,6 +32133,9 @@ const githubLib = __nccwpck_require__(3228);
     PR_TITLE: prTitle,
     PR_HEAD_REF: headRef,
     PR_HEAD_SHA: headSha,
+    PR_HEAD_REPO_OWNER: headRepoOwner,
+    PR_HEAD_REPO_NAME: headRepoName,
+    PR_HEAD_REPO_FULL_NAME: headRepoFullName,
     PR_BASE_REF: baseRef,
     REPO_OWNER: owner,
     REPO_NAME: repoName,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "type": "commonjs",
   "main": "dist/index.js",
   "scripts": {
-    "build": "ncc build src/index.js -o dist"
+    "build": "ncc build src/index.js -o dist",
+    "test": "node --test"
   },
   "dependencies": {
     "@actions/core": "^1.11.1",

--- a/src/blueprint.js
+++ b/src/blueprint.js
@@ -1,0 +1,93 @@
+function normalizePath(path) {
+  const raw = (path || "").trim();
+  if (!raw || raw === "." || raw === "./") {
+    return "";
+  }
+  return raw.replace(/^\.\/+/, "").replace(/^\/+|\/+$/g, "");
+}
+
+function sanitizeSlug(value, fallback) {
+  if (!value) return fallback;
+  const cleaned = value
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return cleaned || fallback;
+}
+
+function inferSlug(path, fallback) {
+  const clean = normalizePath(path).split("/").filter(Boolean).pop();
+  if (!clean || clean === "." || clean === "..") return fallback;
+  return sanitizeSlug(clean, fallback);
+}
+
+function getRepoOwner(repo, fallback) {
+  return repo?.owner?.login || repo?.owner?.name || repo?.owner?.id || fallback;
+}
+
+function getPullRequestHeadRepository(
+  pr,
+  fallbackRepo,
+  fallbackOwner,
+  fallbackRepoName,
+) {
+  const headRepo = pr.head?.repo || fallbackRepo || {};
+  const owner = getRepoOwner(headRepo, fallbackOwner);
+  const name = headRepo.name || fallbackRepoName;
+  const fullName = headRepo.full_name || `${owner}/${name}`;
+
+  return {
+    owner,
+    name,
+    fullName,
+    gitUrl: `https://github.com/${fullName}.git`,
+  };
+}
+
+function buildAutoBlueprint({ pluginPath, themePath, repoGitUrl, ref }) {
+  const steps = [];
+  const gitDirectoryResource = (path) => ({
+    resource: "git:directory",
+    url: repoGitUrl,
+    ref,
+    refType: "commit",
+    path: normalizePath(path) || "/",
+  });
+
+  if (pluginPath) {
+    steps.push({
+      step: "installPlugin",
+      pluginData: gitDirectoryResource(pluginPath),
+      options: {
+        activate: true,
+      },
+    });
+  }
+
+  if (themePath) {
+    steps.push({
+      step: "installTheme",
+      themeData: gitDirectoryResource(themePath),
+      options: {
+        activate: true,
+      },
+    });
+  }
+
+  return JSON.stringify({
+    $schema: "https://playground.wordpress.net/blueprint-schema.json",
+    preferredVersions: {
+      php: "8.2",
+      wp: "latest",
+    },
+    steps,
+  });
+}
+
+module.exports = {
+  buildAutoBlueprint,
+  getPullRequestHeadRepository,
+  inferSlug,
+  normalizePath,
+  sanitizeSlug,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,11 @@
 const core = require('@actions/core');
 const githubLib = require('@actions/github');
+const {
+  buildAutoBlueprint,
+  getPullRequestHeadRepository,
+  inferSlug,
+  sanitizeSlug,
+} = require('./blueprint');
 
 (async () => {
   const context = githubLib.context;
@@ -58,6 +64,10 @@ const githubLib = require('@actions/github');
   const prTitle = pr.title;
   const headRef = pr.head.ref;
   const headSha = pr.head.sha;
+  const headRepo = getPullRequestHeadRepository(pr, repo, owner, repoName);
+  const headRepoOwner = headRepo.owner;
+  const headRepoName = headRepo.name;
+  const headRepoFullName = headRepo.fullName;
   const baseRef = pr.base.ref;
 
   const playgroundHostRaw = core.getInput('playground-host', {required: false}) || 'https://playground.wordpress.net';
@@ -92,87 +102,21 @@ const githubLib = require('@actions/github');
 
   const archiveBranchSegment = headRef.replace(/[^0-9A-Za-z]/g, '-');
   const repoArchiveRoot = `${repoName}-${archiveBranchSegment}`;
-  const repoGitUrl = `https://github.com/${repoFullName}.git`;
-
-  const normalizePath = (path) => {
-    const raw = (path || '').trim();
-    if (!raw || raw === '.' || raw === './') {
-  	return '';
-    }
-    return raw.replace(/^\.\/+/, '').replace(/^\/+|\/+$/g, '');
-  };
-  const sanitizeSlug = (value, fallback) => {
-    if (!value) return fallback;
-    const cleaned = value
-  	.toLowerCase()
-  	.replace(/[^a-z0-9-]+/g, '-')
-  	.replace(/^-+|-+$/g, '');
-    return cleaned || fallback;
-  };
   const repoSlug = sanitizeSlug(repoName, 'project');
-  const inferSlug = (path, fallback) => {
-    const clean = normalizePath(path).split('/').filter(Boolean).pop();
-    if (!clean || clean === '.' || clean === '..') return fallback;
-    return sanitizeSlug(clean, fallback);
-  };
 
   const pluginSlug = pluginPath ? inferSlug(pluginPath, repoSlug) : '';
   const themeSlug = themePath ? inferSlug(themePath, `${repoSlug}-theme`) : '';
-
-  const buildAutoBlueprint = () => {
-    const steps = [];
-
-    if (pluginPath) {
-  	steps.push(
-  	  {
-  		step: 'installPlugin',
-  		pluginData: {
-  		  resource: 'git:directory',
-  		  url: repoGitUrl,
-  		  ref: headRef,
-  		  path: normalizePath(pluginPath) || "/"
-  		},
-  		options: {
-  		  activate: true
-  		}
-  	  }
-  	);
-    }
-
-    if (themePath) {
-  	steps.push(
-  	  {
-  		step: 'installTheme',
-  		themeData: {
-  		  resource: 'git:directory',
-  		  url: repoGitUrl,
-  		  ref: headRef,
-  		  path: normalizePath(themePath) || "/"
-  		},
-  		options: {
-  		  activate: true
-  		}
-  	  }
-  	);
-    }
-
-    return JSON.stringify(
-  	{
-  	  $schema: 'https://playground.wordpress.net/blueprint-schema.json',
-  	  preferredVersions: {
-  		php: '8.2',
-  		wp: 'latest'
-  	  },
-  	  steps
-  	}
-    );
-  };
 
   let blueprintJson = '';
   if (blueprintInput && blueprintInput.trim().length) {
     blueprintJson = blueprintInput.trim();
   } else if (pluginPath || themePath) {
-    blueprintJson = buildAutoBlueprint();
+    blueprintJson = buildAutoBlueprint({
+      pluginPath,
+      themePath,
+      repoGitUrl: headRepo.gitUrl,
+      ref: headSha,
+    });
   }
 
   if (blueprintJson) {
@@ -253,6 +197,9 @@ const githubLib = require('@actions/github');
     PR_TITLE: prTitle,
     PR_HEAD_REF: headRef,
     PR_HEAD_SHA: headSha,
+    PR_HEAD_REPO_OWNER: headRepoOwner,
+    PR_HEAD_REPO_NAME: headRepoName,
+    PR_HEAD_REPO_FULL_NAME: headRepoFullName,
     PR_BASE_REF: baseRef,
     REPO_OWNER: owner,
     REPO_NAME: repoName,


### PR DESCRIPTION
## Summary
- Generate automatic plugin/theme preview Blueprints from the PR head repository instead of the base repository.
- Pin generated `git:directory` resources to `pull_request.head.sha` with `refType: "commit"` so fork PR previews load the exact reviewed code.
- Add PR head repository template variables, constrained fork PR guidance for `pull_request_target`, and focused tests for fork/source-repo behavior.

## Validation
- `npm test`
- `npm run build`
- `git diff --check`
