### PR TITLE
Fix artifact cleanup jq field typo (created_at -> createdAt)

### DIFF
--- a/.github/actions/expose-artifact-on-public-url/action.yml
+++ b/.github/actions/expose-artifact-on-public-url/action.yml
@@ -224,7 +224,7 @@ runs:
         fi
 
         gh release view "$RELEASE_TAG" --repo "$release_repo" --json assets \
-          --jq ".assets[] | select(.name | startswith(\"pr-$PR_NUMBER-\")) | \"\(.created_at)|\(.name)\"" \
+          --jq ".assets[] | select(.name | startswith(\"pr-$PR_NUMBER-\")) | \"\(.createdAt)|\(.name)\"" \
           > pr-artifacts.txt
 
         if [ ! -s pr-artifacts.txt ]; then


### PR DESCRIPTION
## Summary
- Fix jq field name in the cleanup step of `expose-artifact-on-public-url`: `gh release view --json assets` returns `createdAt`, not `created_at`. The old field evaluated to `null` for every asset, so `sort -r` fell back to reverse-alphabetical filename order and could delete the asset just uploaded in the same step.

Fixes #72

## Test plan
- [ ] Verify on a PR with >N artifacts that `artifacts-to-keep: N` keeps the N most-recently-uploaded assets and deletes older ones, regardless of SHA ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)