### PR TITLE
Fix immutable action publisher reference

### DIFF
--- a/.github/workflows/publish-immutable-action.yml
+++ b/.github/workflows/publish-immutable-action.yml
@@ -17,4 +17,4 @@ jobs:
         uses: actions/checkout@v4
       - name: Publish
         id: publish
-        uses: actions/publish-immutable-action@0.0.4
+        uses: actions/publish-immutable-action@v0.0.4


### PR DESCRIPTION
Use the existing v0.0.4 tag for actions/publish-immutable-action so release publishing can resolve the action.