### PR TITLE
Fix template button diff-check whitespace

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -32042,7 +32042,7 @@ const githubLib = __nccwpck_require__(3228);
 
   	// Escape HTML entities somewhat naively to prevent the values leaking
   	// into HTML syntax elements.
-  	if(upperKey !== 'PLAYGROUND_BUTTON') {
+	  if (upperKey !== 'PLAYGROUND_BUTTON') {
   	  value = value
   		.replace(/&/g, '&amp;')
   		.replace(/</g, '&lt;')

--- a/src/index.js
+++ b/src/index.js
@@ -206,7 +206,7 @@ const githubLib = require('@actions/github');
 
   	// Escape HTML entities somewhat naively to prevent the values leaking
   	// into HTML syntax elements.
-  	if(upperKey !== 'PLAYGROUND_BUTTON') {
+	  if (upperKey !== 'PLAYGROUND_BUTTON') {
   	  value = value
   		.replace(/&/g, '&amp;')
   		.replace(/</g, '&lt;')


### PR DESCRIPTION
Fixes the whitespace introduced in the PLAYGROUND_BUTTON case-insensitive template check so git diff --check passes on the v3 codebase. Rebuilds dist.