### PR TITLE
Fix release asset cleanup timestamp field

### DIFF
--- a/.github/actions/expose-artifact-on-public-url/action.yml
+++ b/.github/actions/expose-artifact-on-public-url/action.yml
@@ -227,7 +227,7 @@ runs:
         fi
 
         gh release view "$RELEASE_TAG" --repo "$release_repo" --json assets \
-          --jq ".assets[] | select(.name | startswith(\"pr-$PR_NUMBER-\")) | \"\(.created_at)|\(.name)\"" \
+          --jq ".assets[] | select(.name | startswith(\"pr-$PR_NUMBER-\")) | \"\(.createdAt)|\(.name)\"" \
           > pr-artifacts.txt
 
         if [ ! -s pr-artifacts.txt ]; then

--- a/.github/workflows/preview-publish.yml
+++ b/.github/workflows/preview-publish.yml
@@ -308,7 +308,7 @@ jobs:
           # Group assets by SHA so each PR keeps N most recent commit sets,
           # not N individual zips (a single commit may upload several zips).
           gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json assets \
-            --jq ".assets[] | select(.name | startswith(\"pr-$PR_NUMBER-\")) | \"\(.created_at)|\(.name)\"" \
+            --jq ".assets[] | select(.name | startswith(\"pr-$PR_NUMBER-\")) | \"\(.createdAt)|\(.name)\"" \
             > pr-assets.txt || true
           [ -s pr-assets.txt ] || exit 0
 

--- a/scripts/test-preview-workflows.mjs
+++ b/scripts/test-preview-workflows.mjs
@@ -5,6 +5,10 @@ const publishWorkflow = readFileSync(
   new URL('../.github/workflows/preview-publish.yml', import.meta.url),
   'utf8'
 );
+const exposeArtifactAction = readFileSync(
+  new URL('../.github/actions/expose-artifact-on-public-url/action.yml', import.meta.url),
+  'utf8'
+);
 const readme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
 
 test('wrong-trigger misuse fails in the guard step, not at job level', () => {
@@ -64,6 +68,14 @@ test('publish workflow validates release retention before uploading assets', () 
   );
   assert.match(publishWorkflow, /\[\[ "\$ARTIFACTS_TO_KEEP" =~ \^\[0-9\]\+\$ \]\]/);
   assert.match(publishWorkflow, /\[ "\$ARTIFACTS_TO_KEEP" -lt 1 \]/);
+});
+
+
+test('cleanup sorts release assets by the GitHub CLI createdAt field', () => {
+  assert.doesNotMatch(publishWorkflow, /created_at/);
+  assert.match(publishWorkflow, /createdAt/);
+  assert.doesNotMatch(exposeArtifactAction, /created_at/);
+  assert.match(exposeArtifactAction, /createdAt/);
 });
 
 function test(name, fn) {


### PR DESCRIPTION
Fixes release asset cleanup to use the GitHub CLI's camelCase createdAt field instead of created_at. This applies both the legacy expose-artifact-on-public-url helper and the v3 preview-publish reusable workflow.\n\nFixes #72.