### PR TITLE
Update Node version from 20 to 24 in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ secrets:
     required: false
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
 
 outputs:


### PR DESCRIPTION
## Summary

Node.js 20 support on GitHub runner is [deprecated](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), so need to update

Closes: #83 