### PR TITLE
Add Blueprint preview variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,80 @@ Use this when a PR should preview a plugin and a theme from the same repository.
     github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+### Multiple preview variants
+
+Use this when reviewers need more than one Playground link for the same PR: a
+PHP support range, a WordPress version check, or a feature flag setup. The
+short syntax covers common version and feature toggles:
+
+```yaml
+- uses: WordPress/action-wp-playground-pr-preview@v3
+  with:
+    plugin-path: .
+    preview-variants: '["php:8.4", "php:8.2", "wp:6.8", "features:networking"]'
+    mode: comment
+    comment-template: |
+      ### WordPress Playground Preview
+
+      Test this PR with:
+
+      {{PLAYGROUND_URLS_MARKDOWN}}
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Supported string shorthands are:
+
+- `php:<version>` — sets `preferredVersions.php`
+- `wp:<version>` or `wordpress:<version>` — sets `preferredVersions.wp`
+- `feature:<name>` or `features:<name>[,<name>]` — enables one or more
+  Blueprint `features`
+
+For combined or scenario-specific previews, use objects. `php` and `wp` are
+short aliases for `preferredVersions`, while other fields are merged into the
+base Blueprint:
+
+```yaml
+preview-variants: |
+  [
+    {
+      "label": "PHP 8.4 / WordPress latest",
+      "php": "8.4",
+      "wp": "latest"
+    },
+    {
+      "label": "Checkout flow with networking",
+      "php": "8.2",
+      "features": { "networking": true },
+      "landingPage": "/wp-admin/admin.php?page=my-plugin",
+      "siteOptions": {
+        "blogname": "Checkout review"
+      },
+      "appendSteps": [
+        {
+          "step": "runPHP",
+          "code": "<?php require '/wordpress/wp-load.php'; update_option('my_plugin_mode', 'checkout');"
+        }
+      ]
+    }
+  ]
+```
+
+Variant objects keep the generated plugin/theme install steps by default.
+`preferredVersions`, `features`, and `siteOptions` merge with the base
+Blueprint; `prependSteps` run before the base steps; `appendSteps` run after the
+base steps. Raw `steps` are rejected so a variant does not accidentally remove
+the install step. If you need the unchanged default preview alongside variants,
+include `{ "label": "Default" }` as one of the entries.
+
+Existing one-button workflows keep working: `{{PLAYGROUND_BUTTON}}` and the
+`preview-url` output point to the first generated preview. Use
+`{{PLAYGROUND_URLS_MARKDOWN}}` or `preview-urls-json` when you want to show the
+full list.
+
+Trade-off: `preview-variants` does not work with `blueprint-url`, because the
+action cannot safely rewrite a remote Blueprint once per variant. Use
+`plugin-path`, `theme-path`, or inline `blueprint` when you need variants.
+
 ### Custom blueprint (companion plugins, version pin, seed data, login)
 
 When you need more than "install this plugin," provide a full Blueprint via `blueprint:`. Example: install your plugin from the PR, also install WooCommerce from .org, pin PHP and WP versions, and log in as admin.
@@ -626,6 +700,7 @@ Use directly when there's no build step, or have the publish workflow call it (i
 | `theme-path` | one of four† | — | Path to theme directory. Auto-generates a `git:directory` blueprint. |
 | `blueprint` | one of four† | — | Custom Blueprint as a JSON string. When set, `plugin-path` and `theme-path` are ignored. |
 | `blueprint-url` | one of four† | — | URL pointing to a hosted Blueprint JSON. Used directly via `?blueprint-url=…`. |
+| `preview-variants` | no | — | JSON array of preview variants. String shorthands support `php:<version>`, `wp:<version>`, and `features:<name>[,<name>]`; object entries merge Blueprint fields into the base preview. Not supported with `blueprint-url`. |
 | `description-template` | no | `{{PLAYGROUND_BUTTON}}` | Template for the PR description block. Supports the [template variables](#template-variables). |
 | `comment-template` | no | (full default) | Template for the PR comment. Supports the [template variables](#template-variables). |
 | `restore-button-if-removed` | no | `true` | If the PR author removes the button block, restore it on the next run. Set `false` to respect deletions. Only applies to `append-to-description` mode. |
@@ -638,8 +713,9 @@ Use directly when there's no build step, or have the publish workflow call it (i
 
 | Output | Description |
 |---|---|
-| `preview-url` | Full Playground URL embedded in the button. |
-| `blueprint-json` | Rendered Blueprint JSON string. Empty when `blueprint-url` is used. |
+| `preview-url` | Full Playground URL embedded in the button. When variants are configured, this is the first generated preview. |
+| `preview-urls-json` | JSON array of generated preview links, each with `label` and `url`. |
+| `blueprint-json` | Rendered Blueprint JSON string. Empty when `blueprint-url` is used. When variants are configured, this is the first generated Blueprint. |
 | `rendered-description` | Markdown/HTML inserted into the PR description (when `mode: append-to-description`). |
 | `rendered-comment` | Markdown/HTML used for the PR comment (when `mode: comment`). |
 | `mode` | Effective mode (`append-to-description` or `comment`). |
@@ -695,7 +771,9 @@ Available in `description-template` and `comment-template` strings (case-insensi
 | Variable | Value |
 |---|---|
 | `PLAYGROUND_BUTTON` | Full button HTML — recommended in any custom template. |
-| `PLAYGROUND_URL` | Full Playground URL with embedded blueprint. |
+| `PLAYGROUND_URL` | Full Playground URL with embedded blueprint. When variants are configured, this is the first generated preview. |
+| `PLAYGROUND_URLS_MARKDOWN` | Markdown list of all generated preview links. |
+| `PLAYGROUND_URLS_JSON` | JSON array of generated preview links, each with `label` and `url`. |
 | `PLAYGROUND_BUTTON_IMAGE_URL` | URL of the button image asset. |
 | `PLAYGROUND_BLUEPRINT_JSON` | Stringified Blueprint JSON. Empty when `blueprint-url` is used. |
 | `PLAYGROUND_BLUEPRINT_DATA_URL` | Blueprint data URL, or the provided `blueprint-url` when `blueprint-url` is used. |

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   blueprint-url:
     type: string
     description: 'URL pointing to a remote blueprint. When provided, the Playground link uses `?blueprint-url={url}` directly.'
+  preview-variants:
+    type: string
+    description: 'JSON array of preview variants. String shorthands support php:<version>, wp:<version>, and features:<name>[,<name>]. Objects merge Blueprint fields into the base preview.'
   plugin-path:
     type: string
     description: Path to plugin directory inside the repository (e.g., `.` for root or `plugins/my-plugin`)
@@ -55,6 +58,8 @@ runs:
 outputs:
   preview-url:
     description: Direct link to the generated WordPress Playground instance.
+  preview-urls-json:
+    description: JSON array of generated preview links, each with label and url.
   blueprint-json:
     description: JSON blueprint (stringified) used for the preview.
   rendered-description:

--- a/dist/index.js
+++ b/dist/index.js
@@ -31903,6 +31903,7 @@ const githubLib = __nccwpck_require__(3228);
   const themePath = (core.getInput('theme-path', {required: false}) || '').trim();
   const blueprintInput = core.getInput('blueprint', {required: false}) || '';
   const blueprintUrlInput = (core.getInput('blueprint-url', {required: false}) || '').trim();
+  const previewVariantsInput = core.getInput('preview-variants', {required: false}) || '';
 
   if(!pluginPath && !themePath && !blueprintInput && !blueprintUrlInput) {
     throw new Error('One of `plugin-path`, `theme-path`, `blueprint`, or `blueprint-url` inputs is required.');
@@ -31924,6 +31925,136 @@ const githubLib = __nccwpck_require__(3228);
     } catch (error) {
   	throw new Error(`Unable to parse ${label} as JSON. ${error.message}`);
     }
+  };
+
+  const parsePreviewVariantString = (value) => {
+    const separator = value.indexOf(':');
+    if (separator === -1) {
+      throw new Error(`Invalid preview variant shorthand: ${value}. Expected php:<version>, wp:<version>, or features:<name>[,<name>].`);
+    }
+
+    const kind = value.slice(0, separator).trim().toLowerCase();
+    const rawValue = value.slice(separator + 1).trim();
+    if (!rawValue) {
+      throw new Error(`Invalid preview variant shorthand: ${value}. The value after ':' must not be empty.`);
+    }
+
+    if (kind === 'php') {
+      return { label: `PHP ${rawValue}`, preferredVersions: { php: rawValue } };
+    }
+    if (kind === 'wp' || kind === 'wordpress') {
+      return { label: `WordPress ${rawValue}`, preferredVersions: { wp: rawValue } };
+    }
+    if (kind === 'feature' || kind === 'features') {
+      const features = rawValue.split(',').map((feature) => feature.trim()).filter(Boolean);
+      if (!features.length) {
+        throw new Error(`Invalid preview variant shorthand: ${value}. At least one feature name is required.`);
+      }
+      return {
+        label: features.length === 1 ? `Feature: ${features[0]}` : `Features: ${features.join(', ')}`,
+        features: Object.fromEntries(features.map((feature) => [feature, true]))
+      };
+    }
+
+    throw new Error(`Invalid preview variant shorthand: ${value}. Expected php:<version>, wp:<version>, or features:<name>[,<name>].`);
+  };
+
+  const normalizePreviewVariant = (entry, index) => {
+    if (typeof entry === 'string') {
+      return parsePreviewVariantString(entry.trim());
+    }
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new Error(`preview-variants[${index}] must be a string shorthand or an object.`);
+    }
+
+    const { label, php, wp, wordpress, ...blueprintPatch } = entry;
+    const preferredVersions = { ...(blueprintPatch.preferredVersions || {}) };
+    if (php !== undefined) {
+      preferredVersions.php = String(php);
+    }
+    if (wp !== undefined || wordpress !== undefined) {
+      preferredVersions.wp = String(wp !== undefined ? wp : wordpress);
+    }
+    if (Object.keys(preferredVersions).length) {
+      blueprintPatch.preferredVersions = preferredVersions;
+    }
+
+    return {
+      label: typeof label === 'string' && label.trim() ? label.trim() : '',
+      ...blueprintPatch
+    };
+  };
+
+  const parsePreviewVariants = (input) => {
+    const variants = safeParseJson('preview-variants', input, []);
+    if (!Array.isArray(variants)) {
+      throw new Error('preview-variants must be a JSON array.');
+    }
+    return variants.map(normalizePreviewVariant);
+  };
+
+  const describePreviewVariant = (variant, index) => {
+    if (variant.label) {
+      return variant.label;
+    }
+
+    const parts = [];
+    if (variant.preferredVersions && variant.preferredVersions.php) {
+      parts.push(`PHP ${variant.preferredVersions.php}`);
+    }
+    if (variant.preferredVersions && variant.preferredVersions.wp) {
+      parts.push(`WordPress ${variant.preferredVersions.wp}`);
+    }
+    if (variant.features && Object.keys(variant.features).length) {
+      parts.push(`Features: ${Object.keys(variant.features).join(', ')}`);
+    }
+    return parts.length ? parts.join(' / ') : `Preview ${index + 1}`;
+  };
+
+  const mergeBlueprintVariant = (baseBlueprintJson, variant, index) => {
+    const base = safeParseJson('base blueprint', baseBlueprintJson);
+    const { label, prependSteps, appendSteps, siteOptions, ...override } = variant;
+
+    if (Object.prototype.hasOwnProperty.call(override, 'steps')) {
+      throw new Error('preview-variants entries must use prependSteps or appendSteps instead of steps.');
+    }
+
+    const merged = {
+      ...base,
+      ...override,
+      preferredVersions: {
+        ...(base.preferredVersions || {}),
+        ...(override.preferredVersions || {}),
+      },
+      features: {
+        ...(base.features || {}),
+        ...(override.features || {}),
+      },
+    };
+
+    const steps = Array.isArray(base.steps) ? [...base.steps] : [];
+    if (siteOptions && typeof siteOptions === 'object' && !Array.isArray(siteOptions)) {
+      const siteOptionsStep = steps.find((step) => step && step.step === 'setSiteOptions');
+      if (siteOptionsStep) {
+        siteOptionsStep.options = {
+          ...(siteOptionsStep.options || {}),
+          ...siteOptions,
+        };
+      } else {
+        steps.unshift({ step: 'setSiteOptions', options: siteOptions });
+      }
+    }
+
+    merged.steps = [
+      ...(Array.isArray(prependSteps) ? prependSteps : []),
+      ...steps,
+      ...(Array.isArray(appendSteps) ? appendSteps : [])
+    ];
+
+    return {
+      label: describePreviewVariant({ label, ...override, siteOptions }, index),
+      blueprintJson: JSON.stringify(merged)
+    };
   };
 
   const archiveBranchSegment = headRef.replace(/[^0-9A-Za-z]/g, '-');
@@ -32011,6 +32142,16 @@ const githubLib = __nccwpck_require__(3228);
     blueprintJson = buildAutoBlueprint();
   }
 
+  const previewVariants = parsePreviewVariants(previewVariantsInput);
+  if (previewVariants.length && blueprintUrlInput) {
+    throw new Error('preview-variants requires an inline Blueprint; blueprint-url cannot be rewritten per variant.');
+  }
+
+  const previewBlueprints = previewVariants.length
+    ? previewVariants.map((variant, index) => mergeBlueprintVariant(blueprintJson, variant, index))
+    : [{ label: 'Preview', blueprintJson }];
+  blueprintJson = previewBlueprints[0] ? previewBlueprints[0].blueprintJson : blueprintJson;
+
   if (blueprintJson) {
     try {
       JSON.parse(blueprintJson);
@@ -32042,7 +32183,7 @@ const githubLib = __nccwpck_require__(3228);
 
   	// Escape HTML entities somewhat naively to prevent the values leaking
   	// into HTML syntax elements.
-	  if (upperKey !== 'PLAYGROUND_BUTTON') {
+	  if (upperKey !== 'PLAYGROUND_BUTTON' && upperKey !== 'PLAYGROUND_URLS_MARKDOWN') {
   	  value = value
   		.replace(/&/g, '&amp;')
   		.replace(/</g, '&lt;')
@@ -32054,14 +32195,29 @@ const githubLib = __nccwpck_require__(3228);
     });
   };
 
-  const blueprintDataUrl = blueprintJson
-    ? `data:application/json,${encodeURIComponent(blueprintJson)}`
-    : '';
-  const finalBlueprintUrl = blueprintUrlInput || blueprintDataUrl;
-  const blueprintQueryValue = blueprintUrlInput
-    ? encodeURIComponent(blueprintUrlInput)
-    : blueprintDataUrl;
-  const previewUrl = `${playgroundHost}${playgroundHost.includes('?') ? '&' : '?'}blueprint-url=${blueprintQueryValue}`;
+  const buildPreviewUrl = (previewBlueprintJson) => {
+    const blueprintDataUrl = previewBlueprintJson
+      ? `data:application/json,${encodeURIComponent(previewBlueprintJson)}`
+      : '';
+    const finalBlueprintUrl = blueprintUrlInput || blueprintDataUrl;
+    const blueprintQueryValue = blueprintUrlInput
+      ? encodeURIComponent(blueprintUrlInput)
+      : blueprintDataUrl;
+
+    return {
+      url: `${playgroundHost}${playgroundHost.includes('?') ? '&' : '?'}blueprint-url=${blueprintQueryValue}`,
+      blueprintDataUrl: finalBlueprintUrl
+    };
+  };
+
+  const previewLinks = previewBlueprints.map((preview) => {
+    const { url, blueprintDataUrl } = buildPreviewUrl(preview.blueprintJson);
+    return { ...preview, url, blueprintDataUrl };
+  });
+  const firstPreview = previewLinks[0];
+  const previewUrl = firstPreview.url;
+  const previewUrlsJson = JSON.stringify(previewLinks.map(({ label, url }) => ({ label, url })));
+  const previewUrlsMarkdown = previewLinks.map(({ label, url }) => `- [${label}](${url})`).join('\n');
 
   const joinWithNewline = (segments) => segments.join('\n');
   const defaultButtonImageUrl = 'https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg';
@@ -32106,8 +32262,10 @@ const githubLib = __nccwpck_require__(3228);
     baseTemplateVars,
     {
   	PLAYGROUND_URL: previewUrl,
+    PLAYGROUND_URLS_JSON: previewUrlsJson,
+    PLAYGROUND_URLS_MARKDOWN: previewUrlsMarkdown,
   	PLAYGROUND_BLUEPRINT_JSON: blueprintJson,
-  	PLAYGROUND_BLUEPRINT_DATA_URL: finalBlueprintUrl,
+    PLAYGROUND_BLUEPRINT_DATA_URL: firstPreview.blueprintDataUrl,
   	PLAYGROUND_BUTTON_IMAGE_URL: defaultButtonImageUrl,
   	PLAYGROUND_BUTTON: substitute(defaultButtonTemplate, {})
     }
@@ -32243,6 +32401,7 @@ const githubLib = __nccwpck_require__(3228);
 
   core.setOutput('mode', mode);
   core.setOutput('preview-url', previewUrl);
+  core.setOutput('preview-urls-json', previewUrlsJson);
   core.setOutput('blueprint-json', blueprintJson);
   core.setOutput('rendered-description', renderedDescription);
   core.setOutput('rendered-comment', renderedComment);

--- a/scripts/test-preview-workflows.mjs
+++ b/scripts/test-preview-workflows.mjs
@@ -9,6 +9,7 @@ const exposeArtifactAction = readFileSync(
   new URL('../.github/actions/expose-artifact-on-public-url/action.yml', import.meta.url),
   'utf8'
 );
+const action = readFileSync(new URL('../action.yml', import.meta.url), 'utf8');
 const readme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
 
 test('wrong-trigger misuse fails in the guard step, not at job level', () => {
@@ -76,6 +77,17 @@ test('cleanup sorts release assets by the GitHub CLI createdAt field', () => {
   assert.match(publishWorkflow, /createdAt/);
   assert.doesNotMatch(exposeArtifactAction, /created_at/);
   assert.match(exposeArtifactAction, /createdAt/);
+});
+
+test('preview variants are documented as a general matrix feature', () => {
+  assert.match(action, /preview-variants:/);
+  assert.match(action, /preview-urls-json:/);
+  assert.doesNotMatch(action, /php-versions:/);
+  assert.match(readme, /Multiple preview variants/);
+  assert.match(readme, /php:<version>/);
+  assert.match(readme, /wp:<version>/);
+  assert.match(readme, /features:<name>/);
+  assert.match(readme, /PLAYGROUND_URLS_MARKDOWN/);
 });
 
 function test(name, fn) {

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,7 @@ const githubLib = require('@actions/github');
   const themePath = (core.getInput('theme-path', {required: false}) || '').trim();
   const blueprintInput = core.getInput('blueprint', {required: false}) || '';
   const blueprintUrlInput = (core.getInput('blueprint-url', {required: false}) || '').trim();
+  const previewVariantsInput = core.getInput('preview-variants', {required: false}) || '';
 
   if(!pluginPath && !themePath && !blueprintInput && !blueprintUrlInput) {
     throw new Error('One of `plugin-path`, `theme-path`, `blueprint`, or `blueprint-url` inputs is required.');
@@ -88,6 +89,136 @@ const githubLib = require('@actions/github');
     } catch (error) {
   	throw new Error(`Unable to parse ${label} as JSON. ${error.message}`);
     }
+  };
+
+  const parsePreviewVariantString = (value) => {
+    const separator = value.indexOf(':');
+    if (separator === -1) {
+      throw new Error(`Invalid preview variant shorthand: ${value}. Expected php:<version>, wp:<version>, or features:<name>[,<name>].`);
+    }
+
+    const kind = value.slice(0, separator).trim().toLowerCase();
+    const rawValue = value.slice(separator + 1).trim();
+    if (!rawValue) {
+      throw new Error(`Invalid preview variant shorthand: ${value}. The value after ':' must not be empty.`);
+    }
+
+    if (kind === 'php') {
+      return { label: `PHP ${rawValue}`, preferredVersions: { php: rawValue } };
+    }
+    if (kind === 'wp' || kind === 'wordpress') {
+      return { label: `WordPress ${rawValue}`, preferredVersions: { wp: rawValue } };
+    }
+    if (kind === 'feature' || kind === 'features') {
+      const features = rawValue.split(',').map((feature) => feature.trim()).filter(Boolean);
+      if (!features.length) {
+        throw new Error(`Invalid preview variant shorthand: ${value}. At least one feature name is required.`);
+      }
+      return {
+        label: features.length === 1 ? `Feature: ${features[0]}` : `Features: ${features.join(', ')}`,
+        features: Object.fromEntries(features.map((feature) => [feature, true]))
+      };
+    }
+
+    throw new Error(`Invalid preview variant shorthand: ${value}. Expected php:<version>, wp:<version>, or features:<name>[,<name>].`);
+  };
+
+  const normalizePreviewVariant = (entry, index) => {
+    if (typeof entry === 'string') {
+      return parsePreviewVariantString(entry.trim());
+    }
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new Error(`preview-variants[${index}] must be a string shorthand or an object.`);
+    }
+
+    const { label, php, wp, wordpress, ...blueprintPatch } = entry;
+    const preferredVersions = { ...(blueprintPatch.preferredVersions || {}) };
+    if (php !== undefined) {
+      preferredVersions.php = String(php);
+    }
+    if (wp !== undefined || wordpress !== undefined) {
+      preferredVersions.wp = String(wp !== undefined ? wp : wordpress);
+    }
+    if (Object.keys(preferredVersions).length) {
+      blueprintPatch.preferredVersions = preferredVersions;
+    }
+
+    return {
+      label: typeof label === 'string' && label.trim() ? label.trim() : '',
+      ...blueprintPatch
+    };
+  };
+
+  const parsePreviewVariants = (input) => {
+    const variants = safeParseJson('preview-variants', input, []);
+    if (!Array.isArray(variants)) {
+      throw new Error('preview-variants must be a JSON array.');
+    }
+    return variants.map(normalizePreviewVariant);
+  };
+
+  const describePreviewVariant = (variant, index) => {
+    if (variant.label) {
+      return variant.label;
+    }
+
+    const parts = [];
+    if (variant.preferredVersions && variant.preferredVersions.php) {
+      parts.push(`PHP ${variant.preferredVersions.php}`);
+    }
+    if (variant.preferredVersions && variant.preferredVersions.wp) {
+      parts.push(`WordPress ${variant.preferredVersions.wp}`);
+    }
+    if (variant.features && Object.keys(variant.features).length) {
+      parts.push(`Features: ${Object.keys(variant.features).join(', ')}`);
+    }
+    return parts.length ? parts.join(' / ') : `Preview ${index + 1}`;
+  };
+
+  const mergeBlueprintVariant = (baseBlueprintJson, variant, index) => {
+    const base = safeParseJson('base blueprint', baseBlueprintJson);
+    const { label, prependSteps, appendSteps, siteOptions, ...override } = variant;
+
+    if (Object.prototype.hasOwnProperty.call(override, 'steps')) {
+      throw new Error('preview-variants entries must use prependSteps or appendSteps instead of steps.');
+    }
+
+    const merged = {
+      ...base,
+      ...override,
+      preferredVersions: {
+        ...(base.preferredVersions || {}),
+        ...(override.preferredVersions || {}),
+      },
+      features: {
+        ...(base.features || {}),
+        ...(override.features || {}),
+      },
+    };
+
+    const steps = Array.isArray(base.steps) ? [...base.steps] : [];
+    if (siteOptions && typeof siteOptions === 'object' && !Array.isArray(siteOptions)) {
+      const siteOptionsStep = steps.find((step) => step && step.step === 'setSiteOptions');
+      if (siteOptionsStep) {
+        siteOptionsStep.options = {
+          ...(siteOptionsStep.options || {}),
+          ...siteOptions,
+        };
+      } else {
+        steps.unshift({ step: 'setSiteOptions', options: siteOptions });
+      }
+    }
+
+    merged.steps = [
+      ...(Array.isArray(prependSteps) ? prependSteps : []),
+      ...steps,
+      ...(Array.isArray(appendSteps) ? appendSteps : [])
+    ];
+
+    return {
+      label: describePreviewVariant({ label, ...override, siteOptions }, index),
+      blueprintJson: JSON.stringify(merged)
+    };
   };
 
   const archiveBranchSegment = headRef.replace(/[^0-9A-Za-z]/g, '-');
@@ -175,6 +306,16 @@ const githubLib = require('@actions/github');
     blueprintJson = buildAutoBlueprint();
   }
 
+  const previewVariants = parsePreviewVariants(previewVariantsInput);
+  if (previewVariants.length && blueprintUrlInput) {
+    throw new Error('preview-variants requires an inline Blueprint; blueprint-url cannot be rewritten per variant.');
+  }
+
+  const previewBlueprints = previewVariants.length
+    ? previewVariants.map((variant, index) => mergeBlueprintVariant(blueprintJson, variant, index))
+    : [{ label: 'Preview', blueprintJson }];
+  blueprintJson = previewBlueprints[0] ? previewBlueprints[0].blueprintJson : blueprintJson;
+
   if (blueprintJson) {
     try {
       JSON.parse(blueprintJson);
@@ -206,7 +347,7 @@ const githubLib = require('@actions/github');
 
   	// Escape HTML entities somewhat naively to prevent the values leaking
   	// into HTML syntax elements.
-	  if (upperKey !== 'PLAYGROUND_BUTTON') {
+	  if (upperKey !== 'PLAYGROUND_BUTTON' && upperKey !== 'PLAYGROUND_URLS_MARKDOWN') {
   	  value = value
   		.replace(/&/g, '&amp;')
   		.replace(/</g, '&lt;')
@@ -218,14 +359,29 @@ const githubLib = require('@actions/github');
     });
   };
 
-  const blueprintDataUrl = blueprintJson
-    ? `data:application/json,${encodeURIComponent(blueprintJson)}`
-    : '';
-  const finalBlueprintUrl = blueprintUrlInput || blueprintDataUrl;
-  const blueprintQueryValue = blueprintUrlInput
-    ? encodeURIComponent(blueprintUrlInput)
-    : blueprintDataUrl;
-  const previewUrl = `${playgroundHost}${playgroundHost.includes('?') ? '&' : '?'}blueprint-url=${blueprintQueryValue}`;
+  const buildPreviewUrl = (previewBlueprintJson) => {
+    const blueprintDataUrl = previewBlueprintJson
+      ? `data:application/json,${encodeURIComponent(previewBlueprintJson)}`
+      : '';
+    const finalBlueprintUrl = blueprintUrlInput || blueprintDataUrl;
+    const blueprintQueryValue = blueprintUrlInput
+      ? encodeURIComponent(blueprintUrlInput)
+      : blueprintDataUrl;
+
+    return {
+      url: `${playgroundHost}${playgroundHost.includes('?') ? '&' : '?'}blueprint-url=${blueprintQueryValue}`,
+      blueprintDataUrl: finalBlueprintUrl
+    };
+  };
+
+  const previewLinks = previewBlueprints.map((preview) => {
+    const { url, blueprintDataUrl } = buildPreviewUrl(preview.blueprintJson);
+    return { ...preview, url, blueprintDataUrl };
+  });
+  const firstPreview = previewLinks[0];
+  const previewUrl = firstPreview.url;
+  const previewUrlsJson = JSON.stringify(previewLinks.map(({ label, url }) => ({ label, url })));
+  const previewUrlsMarkdown = previewLinks.map(({ label, url }) => `- [${label}](${url})`).join('\n');
 
   const joinWithNewline = (segments) => segments.join('\n');
   const defaultButtonImageUrl = 'https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg';
@@ -270,8 +426,10 @@ const githubLib = require('@actions/github');
     baseTemplateVars,
     {
   	PLAYGROUND_URL: previewUrl,
+    PLAYGROUND_URLS_JSON: previewUrlsJson,
+    PLAYGROUND_URLS_MARKDOWN: previewUrlsMarkdown,
   	PLAYGROUND_BLUEPRINT_JSON: blueprintJson,
-  	PLAYGROUND_BLUEPRINT_DATA_URL: finalBlueprintUrl,
+    PLAYGROUND_BLUEPRINT_DATA_URL: firstPreview.blueprintDataUrl,
   	PLAYGROUND_BUTTON_IMAGE_URL: defaultButtonImageUrl,
   	PLAYGROUND_BUTTON: substitute(defaultButtonTemplate, {})
     }
@@ -407,6 +565,7 @@ const githubLib = require('@actions/github');
 
   core.setOutput('mode', mode);
   core.setOutput('preview-url', previewUrl);
+  core.setOutput('preview-urls-json', previewUrlsJson);
   core.setOutput('blueprint-json', blueprintJson);
   core.setOutput('rendered-description', renderedDescription);
   core.setOutput('rendered-comment', renderedComment);


### PR DESCRIPTION
## What it does

Replaces the PHP-only preview matrix idea with a general `preview-variants` input. A workflow can now render several Playground links for the same PR: PHP versions, WordPress versions, feature toggles, or fuller scenario-specific Blueprint overlays.

Short syntax for common cases:

```yaml
- uses: WordPress/action-wp-playground-pr-preview@v3
  with:
    plugin-path: .
    preview-variants: '["php:8.4", "php:8.2", "wp:6.8", "features:networking"]'
    mode: comment
    comment-template: |
      ### WordPress Playground Preview

      Test this PR with:

      {{PLAYGROUND_URLS_MARKDOWN}}
    github-token: ${{ secrets.GITHUB_TOKEN }}
```

Object syntax for combined or more nuanced previews:

```yaml
preview-variants: |
  [
    {
      "label": "PHP 8.4 / WordPress latest",
      "php": "8.4",
      "wp": "latest"
    },
    {
      "label": "Checkout flow with networking",
      "php": "8.2",
      "features": { "networking": true },
      "landingPage": "/wp-admin/admin.php?page=my-plugin",
      "siteOptions": {
        "blogname": "Checkout review"
      },
      "appendSteps": [
        {
          "step": "runPHP",
          "code": "<?php require '/wordpress/wp-load.php'; update_option('my_plugin_mode', 'checkout');"
        }
      ]
    }
  ]
```

Existing one-button workflows keep working. `{{PLAYGROUND_BUTTON}}` and the `preview-url` output still point at the first generated preview. Projects that want the full list can use `{{PLAYGROUND_URLS_MARKDOWN}}`, `{{PLAYGROUND_URLS_JSON}}`, or the `preview-urls-json` output.

## Rationale

The first version of this PR focused on PHP versions, but the same mechanism is useful for more than PHP compatibility. A plugin maintainer might want:

- PHP 8.4 and PHP 8.2 links
- WordPress latest and a supported older WordPress release
- a networking-enabled Playground
- a scenario link that seeds options and opens a specific admin page

Making this a generic variant layer avoids one input per dimension and keeps the action useful for combinations that are hard to predict up front.

## Implementation

`preview-variants` is a JSON array. Each entry can be either:

- a string shorthand:
  - `php:<version>` → `preferredVersions.php`
  - `wp:<version>` / `wordpress:<version>` → `preferredVersions.wp`
  - `feature:<name>` / `features:<name>[,<name>]` → Blueprint `features`
- an object overlay:
  - `php` and `wp` are aliases for `preferredVersions.php` and `preferredVersions.wp`
  - `preferredVersions`, `features`, and `siteOptions` merge into the base Blueprint
  - `prependSteps` run before the base install steps
  - `appendSteps` run after the base install steps
  - raw `steps` are rejected so a variant does not accidentally remove the plugin/theme install step

The default button and `preview-url` use the first generated variant for backwards compatibility. The new list variables expose all generated links.

Trade-off: `preview-variants` is not supported with `blueprint-url`, because the action cannot reliably fetch, rewrite, and re-host an arbitrary remote Blueprint. Callers that need variants should use `plugin-path`, `theme-path`, or inline `blueprint`.

## Testing instructions

```bash
npm run build
npm test
git diff --check
```

Manual checks:

1. Add `preview-variants: '["php:8.4", "php:8.2", "wp:6.8", "features:networking"]'` and a template containing `{{PLAYGROUND_URLS_MARKDOWN}}`.
2. Open a PR and verify the rendered markdown contains one link per variant.
3. Decode each link’s Blueprint and verify the expected `preferredVersions` or `features` change is present while the generated plugin/theme install step remains.
4. Try an object variant with `siteOptions` and `appendSteps`; verify those merge around the base install step.
5. Try `preview-variants` with `blueprint-url` and verify the action fails with a clear error.
