### PR TITLE
Expose seamless Playground preview URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,28 @@ jobs:
 
 The important connection is the artifact name. `artifacts: my-plugin=...` in the build workflow creates an artifact URL placeholder named `{{ARTIFACT_URL:my-plugin}}` for the publish workflow. Use that placeholder anywhere a Blueprint needs the public ZIP URL.
 
+### Link to normal and seamless Playground modes
+
+The action always computes both the default Playground URL and a seamless-mode
+URL. Use `{{PLAYGROUND_URL_SEAMLESS}}` in a custom template when reviewers
+should be able to choose either presentation.
+
+```yaml
+- uses: WordPress/action-wp-playground-pr-preview@v3
+  with:
+    plugin-path: .
+    mode: comment
+    comment-template: |
+      ### WordPress Playground Preview
+
+      - [Normal Playground]({{PLAYGROUND_URL}})
+      - [Seamless Playground]({{PLAYGROUND_URL_SEAMLESS}})
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+The default `{{PLAYGROUND_BUTTON}}` still points at `{{PLAYGROUND_URL}}`, so
+existing workflows are unchanged.
+
 ### Post the button as a comment instead of editing the description
 
 ```yaml
@@ -639,6 +661,7 @@ Use directly when there's no build step, or have the publish workflow call it (i
 | Output | Description |
 |---|---|
 | `preview-url` | Full Playground URL embedded in the button. |
+| `seamless-preview-url` | Full Playground URL in seamless mode. |
 | `blueprint-json` | Rendered Blueprint JSON string. Empty when `blueprint-url` is used. |
 | `rendered-description` | Markdown/HTML inserted into the PR description (when `mode: append-to-description`). |
 | `rendered-comment` | Markdown/HTML used for the PR comment (when `mode: comment`). |
@@ -696,6 +719,7 @@ Available in `description-template` and `comment-template` strings (case-insensi
 |---|---|
 | `PLAYGROUND_BUTTON` | Full button HTML — recommended in any custom template. |
 | `PLAYGROUND_URL` | Full Playground URL with embedded blueprint. |
+| `PLAYGROUND_URL_SEAMLESS` | Full Playground URL with `mode=seamless`. |
 | `PLAYGROUND_BUTTON_IMAGE_URL` | URL of the button image asset. |
 | `PLAYGROUND_BLUEPRINT_JSON` | Stringified Blueprint JSON. Empty when `blueprint-url` is used. |
 | `PLAYGROUND_BLUEPRINT_DATA_URL` | Blueprint data URL, or the provided `blueprint-url` when `blueprint-url` is used. |

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,8 @@ runs:
 outputs:
   preview-url:
     description: Direct link to the generated WordPress Playground instance.
+  seamless-preview-url:
+    description: Direct link to the generated WordPress Playground instance in seamless mode.
   blueprint-json:
     description: JSON blueprint (stringified) used for the preview.
   rendered-description:

--- a/dist/index.js
+++ b/dist/index.js
@@ -32061,7 +32061,10 @@ const githubLib = __nccwpck_require__(3228);
   const blueprintQueryValue = blueprintUrlInput
     ? encodeURIComponent(blueprintUrlInput)
     : blueprintDataUrl;
-  const previewUrl = `${playgroundHost}${playgroundHost.includes('?') ? '&' : '?'}blueprint-url=${blueprintQueryValue}`;
+  const withPlaygroundQuery = (query) =>
+    `${playgroundHost}${playgroundHost.includes('?') ? '&' : '?'}${query}`;
+  const previewUrl = withPlaygroundQuery(`blueprint-url=${blueprintQueryValue}`);
+  const seamlessPreviewUrl = withPlaygroundQuery(`mode=seamless&blueprint-url=${blueprintQueryValue}`);
 
   const joinWithNewline = (segments) => segments.join('\n');
   const defaultButtonImageUrl = 'https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg';
@@ -32243,6 +32246,7 @@ const githubLib = __nccwpck_require__(3228);
 
   core.setOutput('mode', mode);
   core.setOutput('preview-url', previewUrl);
+  core.setOutput('seamless-preview-url', seamlessPreviewUrl);
   core.setOutput('blueprint-json', blueprintJson);
   core.setOutput('rendered-description', renderedDescription);
   core.setOutput('rendered-comment', renderedComment);

--- a/src/index.js
+++ b/src/index.js
@@ -225,7 +225,10 @@ const githubLib = require('@actions/github');
   const blueprintQueryValue = blueprintUrlInput
     ? encodeURIComponent(blueprintUrlInput)
     : blueprintDataUrl;
-  const previewUrl = `${playgroundHost}${playgroundHost.includes('?') ? '&' : '?'}blueprint-url=${blueprintQueryValue}`;
+  const withPlaygroundQuery = (query) =>
+    `${playgroundHost}${playgroundHost.includes('?') ? '&' : '?'}${query}`;
+  const previewUrl = withPlaygroundQuery(`blueprint-url=${blueprintQueryValue}`);
+  const seamlessPreviewUrl = withPlaygroundQuery(`mode=seamless&blueprint-url=${blueprintQueryValue}`);
 
   const joinWithNewline = (segments) => segments.join('\n');
   const defaultButtonImageUrl = 'https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg';
@@ -407,6 +410,7 @@ const githubLib = require('@actions/github');
 
   core.setOutput('mode', mode);
   core.setOutput('preview-url', previewUrl);
+  core.setOutput('seamless-preview-url', seamlessPreviewUrl);
   core.setOutput('blueprint-json', blueprintJson);
   core.setOutput('rendered-description', renderedDescription);
   core.setOutput('rendered-comment', renderedComment);


### PR DESCRIPTION
## What it does

Exposes a seamless-mode Playground URL alongside the existing default preview URL.

Custom templates can now show both choices:

```yaml
- uses: WordPress/action-wp-playground-pr-preview@v3
  with:
    plugin-path: .
    mode: comment
    comment-template: |
      ### WordPress Playground Preview

      - [Normal Playground]({{PLAYGROUND_URL}})
      - [Seamless Playground]({{PLAYGROUND_URL_SEAMLESS}})
    github-token: ${{ secrets.GITHUB_TOKEN }}
```

The default button still points at `{{PLAYGROUND_URL}}`, so existing workflows keep exactly the same UI.

## Rationale

Some projects want to offer both Playground presentations: the normal UI is useful when reviewers need the full Playground shell, while seamless mode is nicer for focused testing links in a PR comment.

Projects can build this manually today by copying the URL and adding `mode=seamless`, but doing that in every workflow/template is easy to get wrong and duplicates URL construction logic that the action already owns.

## Implementation

- Adds `PLAYGROUND_URL_SEAMLESS` to template variables.
- Adds `seamless-preview-url` as an action output.
- Reuses the same Blueprint query value as the default URL, with `mode=seamless` added before `blueprint-url`.
- Leaves `PLAYGROUND_BUTTON`, `PLAYGROUND_URL`, and `preview-url` unchanged.

## Testing instructions

```bash
npm run build
npm test
git diff --check
```

Manual check:

1. Use a custom `comment-template` containing both `{{PLAYGROUND_URL}}` and `{{PLAYGROUND_URL_SEAMLESS}}`.
2. Open a PR.
3. Verify the first link opens the normal Playground UI.
4. Verify the second link opens `playground.wordpress.net/?mode=seamless#...` / `?mode=seamless&blueprint-url=...` with the same Blueprint.

Trade-off: this PR does not change the default rendered button to show two choices. It only exposes the second URL so projects can opt into the extra link where the additional UI is worth it.
