### PR TITLE
Pass templates through reusable publish workflow

### DIFF
--- a/.github/workflows/preview-publish.yml
+++ b/.github/workflows/preview-publish.yml
@@ -53,6 +53,21 @@ on:
         required: false
         type: string
         default: 'append-to-description'
+      description-template:
+        description: 'Custom markdown/HTML template for PR descriptions. Passed through to the preview action.'
+        required: false
+        type: string
+        default: ''
+      comment-template:
+        description: 'Custom markdown/HTML template for PR comments. Passed through to the preview action.'
+        required: false
+        type: string
+        default: ''
+      restore-button-if-removed:
+        description: 'Whether to restore the preview button if removed by the PR author. Passed through to the preview action.'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -294,6 +309,26 @@ jobs:
             console.log('blueprint=' + JSON.stringify(JSON.parse(blueprint)));
           NODE
 
+      - name: Render artifact URL template variables
+        id: artifact-template-vars
+        if: env.SKIP != '1'
+        shell: bash
+        env:
+          MAPPING_FILE: ${{ steps.urls.outputs.mapping-file }}
+        run: |
+          set -euo pipefail
+          node <<'NODE' >> "$GITHUB_OUTPUT"
+            const fs = require('fs');
+            const urls = JSON.parse(fs.readFileSync(process.env.MAPPING_FILE, 'utf8'));
+            const vars = {};
+            for (const [name, url] of Object.entries(urls)) {
+              const key = `ARTIFACT_URL_${name}`.replace(/[^0-9A-Za-z_]/g, '_').toUpperCase();
+              vars[key] = url;
+            }
+            vars.ARTIFACT_URLS_JSON = urls;
+            console.log('json=' + JSON.stringify(vars));
+          NODE
+
       - name: Cleanup old artifacts
         if: env.SKIP != '1'
         shell: bash
@@ -343,4 +378,8 @@ jobs:
           mode: ${{ inputs.mode }}
           blueprint: ${{ steps.blueprint.outputs.blueprint }}
           pr-number: ${{ steps.meta.outputs.pr-number }}
+          description-template: ${{ inputs.description-template }}
+          comment-template: ${{ inputs.comment-template }}
+          restore-button-if-removed: ${{ inputs.restore-button-if-removed }}
+          template-variables: ${{ steps.artifact-template-vars.outputs.json }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -515,6 +515,29 @@ Or for comment mode:
 
 Available template variables are listed under [Reference → Template variables](#template-variables).
 
+In the reusable publish workflow, the same template inputs are available on
+`preview-publish.yml`:
+
+```yaml
+jobs:
+  publish:
+    uses: WordPress/action-wp-playground-pr-preview/.github/workflows/preview-publish.yml@v3
+    with:
+      kind: plugin
+      mode: comment
+      comment-template: |
+        ## Preview this PR
+
+        {{PLAYGROUND_BUTTON}}
+
+        Download the built plugin: {{ARTIFACT_URL_MY_PLUGIN}}
+```
+
+For reusable workflow templates, each artifact URL is exposed as
+`{{ARTIFACT_URL_<NAME>}}`, uppercased with non-alphanumeric characters replaced
+by underscores. An artifact named `my-plugin` becomes
+`{{ARTIFACT_URL_MY_PLUGIN}}`.
+
 ---
 
 ## Using an LLM to add this to your repository
@@ -621,6 +644,9 @@ Use directly when there's no build step, or have the publish workflow call it (i
 | Input | Required | Default | Description |
 |---|---|---|---|
 | `mode` | no | `append-to-description` | `append-to-description` or `comment`. |
+| `description-template` | no | — | Template passed through to the preview action for PR description mode. |
+| `comment-template` | no | — | Template passed through to the preview action for comment mode. |
+| `restore-button-if-removed` | no | `true` | Passed through to the preview action for PR description mode. |
 | `playground-host` | no | `https://playground.wordpress.net` | Base Playground host URL. |
 | `plugin-path` | one of four† | — | Path to plugin directory. `.` for repo root, `plugins/foo` for subdir. Auto-generates a `git:directory` blueprint. |
 | `theme-path` | one of four† | — | Path to theme directory. Auto-generates a `git:directory` blueprint. |
@@ -628,6 +654,7 @@ Use directly when there's no build step, or have the publish workflow call it (i
 | `blueprint-url` | one of four† | — | URL pointing to a hosted Blueprint JSON. Used directly via `?blueprint-url=…`. |
 | `description-template` | no | `{{PLAYGROUND_BUTTON}}` | Template for the PR description block. Supports the [template variables](#template-variables). |
 | `comment-template` | no | (full default) | Template for the PR comment. Supports the [template variables](#template-variables). |
+| `template-variables` | no | — | JSON object with additional template variables. Keys are available as `{{KEY}}`. |
 | `restore-button-if-removed` | no | `true` | If the PR author removes the button block, restore it on the next run. Set `false` to respect deletions. Only applies to `append-to-description` mode. |
 | `pr-number` | no | *event payload* | Pull request number. Required when calling from a workflow that doesn't have a `pull_request` event payload (e.g. `workflow_run`). |
 | `github-token` | yes | — | Token with `pull-requests: write` and `contents: read`, usually `${{ secrets.GITHUB_TOKEN }}`. |
@@ -673,6 +700,9 @@ Runs in the privileged `workflow_run` context, exposes the artifact bundle's zip
 | `artifacts-to-keep` | no | `2` | Positive integer number of distinct PR commits worth of zips to keep on the release. Older zips for the same PR get pruned. Set to `keep-all` to disable cleanup. |
 | `release-tag` | no | `ci-artifacts` | Tag used to host artifacts publicly. Auto-created as a prerelease on first use. |
 | `mode` | no | `append-to-description` | `append-to-description` or `comment`. |
+| `description-template` | no | — | Template passed through to the preview action for PR description mode. |
+| `comment-template` | no | — | Template passed through to the preview action for comment mode. |
+| `restore-button-if-removed` | no | `true` | Passed through to the preview action for PR description mode. |
 
 ‡ Provide exactly one of `blueprint`, `kind`, `blueprint-from-artifact`. The publish workflow validates this and fails loudly if zero or two are set.
 
@@ -704,6 +734,8 @@ Available in `description-template` and `comment-template` strings (case-insensi
 | `REPO_OWNER`, `REPO_NAME`, `REPO_FULL_NAME`, `REPO_SLUG`, `REPO_ARCHIVE_ROOT` | Repository metadata. |
 | `PLUGIN_PATH`, `PLUGIN_SLUG` | Set when `plugin-path:` is provided. |
 | `THEME_PATH`, `THEME_SLUG` | Set when `theme-path:` is provided. |
+| `ARTIFACT_URL_<NAME>` | Reusable publish workflow only. Public URL for a named build artifact. |
+| `ARTIFACT_URLS_JSON` | Reusable publish workflow only. JSON object mapping artifact names to public URLs. |
 
 All variables except `PLAYGROUND_BUTTON` are HTML-escaped before substitution.
 

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ inputs:
   comment-template:
     type: string
     description: Custom markdown/HTML template for PR comments (supports {{VARIABLE_NAME}} interpolation)
+  template-variables:
+    type: string
+    description: JSON object with additional template variables. Keys are available as {{KEY}}.
   restore-button-if-removed:
     type: boolean
     description: Whether to restore the preview button if removed by PR author (only applies to `append-to-description` mode)

--- a/dist/index.js
+++ b/dist/index.js
@@ -31910,6 +31910,7 @@ const githubLib = __nccwpck_require__(3228);
 
   const descriptionTemplateInput = core.getInput('description-template', {required: false}) || '';
   const commentTemplateInput = core.getInput('comment-template', {required: false}) || '';
+  const templateVariablesInput = core.getInput('template-variables', {required: false}) || '';
   const descriptionMarkerStart = '<!-- wp-playground-preview:start -->';
   const descriptionMarkerEnd = '<!-- wp-playground-preview:end -->';
   const commentIdentifier = '<!-- wp-playground-preview-comment -->';
@@ -31925,6 +31926,11 @@ const githubLib = __nccwpck_require__(3228);
   	throw new Error(`Unable to parse ${label} as JSON. ${error.message}`);
     }
   };
+
+  const extraTemplateVariables = safeParseJson('template-variables', templateVariablesInput, {});
+  if (Array.isArray(extraTemplateVariables) || typeof extraTemplateVariables !== 'object') {
+    throw new Error('template-variables must be a JSON object.');
+  }
 
   const archiveBranchSegment = headRef.replace(/[^0-9A-Za-z]/g, '-');
   const repoArchiveRoot = `${repoName}-${archiveBranchSegment}`;
@@ -32110,7 +32116,8 @@ const githubLib = __nccwpck_require__(3228);
   	PLAYGROUND_BLUEPRINT_DATA_URL: finalBlueprintUrl,
   	PLAYGROUND_BUTTON_IMAGE_URL: defaultButtonImageUrl,
   	PLAYGROUND_BUTTON: substitute(defaultButtonTemplate, {})
-    }
+    },
+    extraTemplateVariables
   );
 
   templateVariables.PLAYGROUND_BUTTON = substitute(defaultButtonTemplate, templateVariables);

--- a/src/index.js
+++ b/src/index.js
@@ -74,6 +74,7 @@ const githubLib = require('@actions/github');
 
   const descriptionTemplateInput = core.getInput('description-template', {required: false}) || '';
   const commentTemplateInput = core.getInput('comment-template', {required: false}) || '';
+  const templateVariablesInput = core.getInput('template-variables', {required: false}) || '';
   const descriptionMarkerStart = '<!-- wp-playground-preview:start -->';
   const descriptionMarkerEnd = '<!-- wp-playground-preview:end -->';
   const commentIdentifier = '<!-- wp-playground-preview-comment -->';
@@ -89,6 +90,11 @@ const githubLib = require('@actions/github');
   	throw new Error(`Unable to parse ${label} as JSON. ${error.message}`);
     }
   };
+
+  const extraTemplateVariables = safeParseJson('template-variables', templateVariablesInput, {});
+  if (Array.isArray(extraTemplateVariables) || typeof extraTemplateVariables !== 'object') {
+    throw new Error('template-variables must be a JSON object.');
+  }
 
   const archiveBranchSegment = headRef.replace(/[^0-9A-Za-z]/g, '-');
   const repoArchiveRoot = `${repoName}-${archiveBranchSegment}`;
@@ -274,7 +280,8 @@ const githubLib = require('@actions/github');
   	PLAYGROUND_BLUEPRINT_DATA_URL: finalBlueprintUrl,
   	PLAYGROUND_BUTTON_IMAGE_URL: defaultButtonImageUrl,
   	PLAYGROUND_BUTTON: substitute(defaultButtonTemplate, {})
-    }
+    },
+    extraTemplateVariables
   );
 
   templateVariables.PLAYGROUND_BUTTON = substitute(defaultButtonTemplate, templateVariables);


### PR DESCRIPTION
## What it does

Lets the reusable publish workflow pass custom templates through to the underlying preview action, and exposes public artifact URLs as template variables.

```yaml
jobs:
  publish:
    uses: WordPress/action-wp-playground-pr-preview/.github/workflows/preview-publish.yml@v3
    with:
      kind: plugin
      mode: comment
      comment-template: |
        ## Preview this PR

        {{PLAYGROUND_BUTTON}}

        Download the built plugin: {{ARTIFACT_URL_MY_PLUGIN}}
```

An artifact named `my-plugin` becomes `{{ARTIFACT_URL_MY_PLUGIN}}`. The workflow also exposes `{{ARTIFACT_URLS_JSON}}` for templates that want to render or debug the whole mapping.

## Rationale

The direct action already supports `description-template` and `comment-template`, but the reusable build/publish setup does not expose those knobs. Projects that need build artifacts therefore have to choose between the safer reusable workflow and a custom comment format.

That blocks richer previews such as:

- listing normal/seamless links
- grouping links by PHP version
- linking directly to the built ZIP artifact
- adding project-specific test instructions next to the preview button

## Implementation

- Adds `description-template`, `comment-template`, and `restore-button-if-removed` inputs to `preview-publish.yml` and passes them to the preview action.
- Adds a generic `template-variables` action input for extra template variables.
- Builds artifact URL variables from the release asset mapping:
  - `my-plugin` → `ARTIFACT_URL_MY_PLUGIN`
  - `plugin_8_4` → `ARTIFACT_URL_PLUGIN_8_4`
- Keeps the existing default templates unchanged when callers do not pass templates.

## Testing instructions

```bash
npm run build
npm test
git diff --check
```

Manual check in a caller repository:

1. Use the reusable build/publish workflow pair.
2. Add `mode: comment` and a `comment-template` that references `{{ARTIFACT_URL_<NAME>}}`.
3. Open a PR.
4. Verify the preview comment uses the custom template and includes the public ZIP URL.

Trade-off: `preview-publish.yml` currently calls the internal action through a pinned immutable commit. The new `template-variables` input becomes effective in the reusable workflow after the internal action reference is repinned during the next release. The existing template passthrough inputs are still useful independently.
