### PR TITLE
Add reusable build setup knobs

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -36,8 +36,23 @@ on:
         required: false
         type: string
         default: ''
+      node-version-file:
+        description: 'If set, pass node-version-file to actions/setup-node before the build.'
+        required: false
+        type: string
+        default: ''
+      node-cache:
+        description: 'If set, pass cache to actions/setup-node before the build, for example npm.'
+        required: false
+        type: string
+        default: ''
       php-version:
         description: 'If set, run shivammathur/setup-php before the build.'
+        required: false
+        type: string
+        default: ''
+      php-tools:
+        description: 'If set, pass tools to shivammathur/setup-php before the build, for example wp-cli.'
         required: false
         type: string
         default: ''
@@ -73,15 +88,18 @@ jobs:
           persist-credentials: false
           fetch-depth: ${{ inputs.fetch-depth }}
 
-      - if: ${{ inputs.node-version != '' }}
+      - if: ${{ inputs.node-version != '' || inputs.node-version-file != '' }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ inputs.node-version }}
+          node-version-file: ${{ inputs.node-version-file }}
+          cache: ${{ inputs.node-cache }}
 
       - if: ${{ inputs.php-version != '' }}
         uses: shivammathur/setup-php@728c6c6b8cf02c2e48117716a91ee48313958a19 # v2
         with:
           php-version: ${{ inputs.php-version }}
+          tools: ${{ inputs.php-tools }}
 
       - name: Run build command
         working-directory: ${{ inputs.working-directory }}

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ jobs:
     with:
       artifacts: my-plugin=build/my-plugin.zip
       node-version: '20'
+      node-cache: npm
       build-command: |
         npm ci
         npm run build:plugin-zip
@@ -358,6 +359,23 @@ blueprint-from-artifact: true
 ```
 
 Live: [example-monorepo-selective](https://github.com/adamziel/preview-in-playground-button-v3-example-monorepo-selective). PR description blueprints decode to install **only** the plugin(s) the PR touched.
+
+### Use repository-pinned Node or PHP tools in the reusable build
+
+Some plugins keep the Node version in `.nvmrc`, rely on the package-manager
+cache, or need a PHP tool such as `wp-cli` before creating the ZIP. The reusable
+build workflow can pass those setup knobs through to the underlying setup
+actions:
+
+```yaml
+node-version-file: '.nvmrc'
+node-cache: npm
+php-version: '8.3'
+php-tools: wp-cli
+```
+
+The build command remains responsible for installing dependencies and producing
+the ZIP listed in `artifacts`.
 
 ### Plugin with PHP dependencies and built JavaScript/CSS
 
@@ -655,7 +673,10 @@ Runs the caller's build command in the read-only `pull_request` context and bund
 | `build-command` | yes | — | Shell script that produces every path listed in `artifacts`. Runs in `bash`; `set -euo pipefail`-style strictness recommended. |
 | `working-directory` | no | `.` | Working directory for `build-command`. |
 | `node-version` | no | *unset* | If set, runs `actions/setup-node@v4` before `build-command`. |
+| `node-version-file` | no | *unset* | If set, passes `node-version-file` to `actions/setup-node@v4`. Useful for repositories that pin Node in `.nvmrc`. |
+| `node-cache` | no | *unset* | If set, passes `cache` to `actions/setup-node@v4`, for example `npm`. |
 | `php-version` | no | *unset* | If set, runs `shivammathur/setup-php@v2` before `build-command`. |
+| `php-tools` | no | *unset* | If `php-version` is set, passes `tools` to `shivammathur/setup-php@v2`, for example `wp-cli`. |
 | `fetch-depth` | no | `1` | Passed to `actions/checkout@v4`. Set to `0` when the build needs full history (e.g. diff against the base ref). |
 | `blueprint-from-build` | no | *unset* | Path (relative to `working-directory`) to a `blueprint.json` written by `build-command`. Bundled with the artifact for use with `blueprint-from-artifact: true` in publish. Validated as parseable JSON before upload. |
 


### PR DESCRIPTION
## What it does

Adds a few pass-through setup knobs to the reusable build workflow:

```yaml
jobs:
  build:
    uses: WordPress/action-wp-playground-pr-preview/.github/workflows/preview-build.yml@v3
    with:
      artifacts: my-plugin=build/my-plugin.zip
      node-version-file: '.nvmrc'
      node-cache: npm
      php-version: '8.3'
      php-tools: wp-cli
      build-command: |
        npm ci
        npm run build:plugin-zip
```

New inputs:

- `node-version-file` → `actions/setup-node` `node-version-file`
- `node-cache` → `actions/setup-node` `cache`
- `php-tools` → `shivammathur/setup-php` `tools`

## Rationale

Some repositories already pin Node in `.nvmrc`, rely on the setup-node package cache, or need a PHP tool such as `wp-cli` before producing the preview ZIP. Without these inputs, those projects either duplicate the reusable build workflow or move setup logic into less-clear shell workarounds.

This keeps the reusable workflow small while covering common setup-action options.

## Implementation

- Runs `actions/setup-node` when either `node-version` or `node-version-file` is set.
- Passes `node-cache` through as the setup-node `cache` input.
- Passes `php-tools` through when `php-version` causes `shivammathur/setup-php` to run.
- Leaves `build-command` responsible for installing dependencies and producing the ZIP listed in `artifacts`.

## Testing instructions

```bash
npm test
git diff --check
```

Manual check in a caller repository:

1. Set `node-version-file: '.nvmrc'` and `node-cache: npm`.
2. Run the reusable build workflow.
3. Verify setup-node reads `.nvmrc` and enables npm cache.
4. Set `php-version` and `php-tools: wp-cli`.
5. Verify `wp` is available in `build-command`.

Trade-off: this does not expose every setup-node or setup-php option. It only adds the small set needed by common plugin build previews; uncommon setup can still live in `build-command` or a wrapper workflow.
